### PR TITLE
Added customizable props

### DIFF
--- a/PhotoGrid.js
+++ b/PhotoGrid.js
@@ -2,6 +2,7 @@
  * Created by Sivaraj Nagaraj
  */
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { View, Image, Dimensions, Modal, TouchableOpacity } from 'react-native';
 import * as _ from 'lodash';
 
@@ -45,11 +46,20 @@ class PhotoGrid extends Component {
     }
 
     renderItem(item, index, expanded) {
-        const { children } = this.props;
+        const { children, imageProps, ImageComponent } = this.props;
         return (
             <View ref={`_${index}`} key={index} style={[expanded ? styles.expandedView : styles.photoView, { borderRadius: this.props.borderRadius }]}>
                 <TouchableOpacity onPress={() => { this.photoPopupToggle(item, index) }}>
-                    <Image source={{ uri: item.url }} style={[styles.ImageStyle, ...(expanded ? [styles.expandedImage] : []), { borderRadius: this.props.borderRadius }]} />
+                    <ImageComponent
+                        source={{ uri: item.url }}
+                        {...imageProps}
+                        style={[
+                            imageProps && imageProps.style,
+                            styles.ImageStyle,
+                            ...(expanded ? [styles.expandedImage] : []),
+                            { borderRadius: this.props.borderRadius }
+                        ]}
+                    />
                     {children && children(item)}
                 </TouchableOpacity>
             </View>
@@ -248,5 +258,21 @@ const styles = {
     },
 
 }
+
+PhotoGrid.propTypes = {
+    PhotosList: PropTypes.array,
+    borderRadius: PropTypes.number,
+    children: PropTypes.func,
+    imageProps: PropTypes.object,
+    onPressItem: PropTypes.func,
+    ImageComponent: PropTypes.oneOfType([
+        PropTypes.element,
+        PropTypes.object,
+    ])
+};
+
+PhotoGrid.defaultProps = {
+    ImageComponent: Image
+};
 
 export { PhotoGrid };

--- a/PhotoGrid.js
+++ b/PhotoGrid.js
@@ -17,7 +17,11 @@ class PhotoGrid extends Component {
     }
 
     photoPopupToggle(photoUrl) {
-        this.setState({ modalVisible: !this.state.modalVisible, photoUrl });
+        if (this.props.onPressItem) {
+            this.props.onPressItem(photoUrl);
+        } else {
+            this.setState({ modalVisible: !this.state.modalVisible, photoUrl });
+        }
     }
 
     renderChunk() {

--- a/PhotoGrid.js
+++ b/PhotoGrid.js
@@ -265,10 +265,7 @@ PhotoGrid.propTypes = {
     children: PropTypes.func,
     imageProps: PropTypes.object,
     onPressItem: PropTypes.func,
-    ImageComponent: PropTypes.oneOfType([
-        PropTypes.element,
-        PropTypes.object,
-    ])
+    ImageComponent: PropTypes.elementType
 };
 
 PhotoGrid.defaultProps = {

--- a/PhotoGrid.js
+++ b/PhotoGrid.js
@@ -16,11 +16,11 @@ class PhotoGrid extends Component {
 
     }
 
-    photoPopupToggle(photoUrl) {
+    photoPopupToggle(item, index) {
         if (this.props.onPressItem) {
-            this.props.onPressItem(photoUrl);
+            this.props.onPressItem(index);
         } else {
-            this.setState({ modalVisible: !this.state.modalVisible, photoUrl });
+            this.setState({ modalVisible: !this.state.modalVisible, photoUrl: item && item.url });
         }
     }
 
@@ -34,7 +34,7 @@ class PhotoGrid extends Component {
                 return row.map(
                     (rowItem, rowIndex) => {
 
-                        return this.renderPhotoRow(rowItem, rowIndex);
+                        return this.renderPhotoRow(rowItem, rowIndex, index * 9 + rowIndex * 3);
                     }
                 )
 
@@ -43,35 +43,39 @@ class PhotoGrid extends Component {
 
 
     }
-    renderPhotoRow(rowItem, rowIndex) {
+
+    renderItem(item, index, expanded) {
+        const { children } = this.props;
+        return (
+            <View ref={`_${index}`} key={index} style={[expanded ? styles.expandedView : styles.photoView, { borderRadius: this.props.borderRadius }]}>
+                <TouchableOpacity onPress={() => { this.photoPopupToggle(item, index) }}>
+                    <Image source={{ uri: item.url }} style={[styles.ImageStyle, ...(expanded ? [styles.expandedImage] : []), { borderRadius: this.props.borderRadius }]} />
+                    {children && children(item)}
+                </TouchableOpacity>
+            </View>
+        );
+    }
+
+    renderPhotoRow(rowItem, rowIndex, index) {
 
         if (rowIndex == 0) {
-            return this.renderPhotoRow1(rowItem);
+            return this.renderPhotoRow1(rowItem, index);
         }
         else if (rowIndex == 1) {
-            return this.renderPhotoRow2(rowItem);
+            return this.renderPhotoRow2(rowItem, index);
         }
         else if (rowIndex == 2) {
-            return this.renderPhotoRow3(rowItem);
+            return this.renderPhotoRow3(rowItem, index);
         }
 
     }
-    renderPhotoRow1(row) {
-        const { children } = this.props;
-        console.log('row', row);
+    renderPhotoRow1(row, index) {
         return (
-            <View key={1} style={styles.alignCenter}>
+            <View key={index} style={styles.alignCenter}>
                 {
                     row.map(
-                        (item, index) => {
-                            return (
-                                <View key={index} style={[styles.photoView, { borderRadius: this.props.borderRadius }]}>
-                                    <TouchableOpacity onPress={() => { this.photoPopupToggle(item.url) }}>
-                                        <Image source={{ uri: item.url }} style={[styles.ImageStyle, { borderRadius: this.props.borderRadius }]} />
-                                        {children && children(item)}
-                                    </TouchableOpacity>
-                                </View>
-                            )
+                        (item, i) => {
+                            return this.renderItem(item, index + i, false);
                         }
 
                     )
@@ -80,36 +84,20 @@ class PhotoGrid extends Component {
             </View>
         )
     }
-    renderPhotoRow2(row) {
-        const { children } = this.props;
+    renderPhotoRow2(row, index) {
         if (row.length == 1) {
             return (
-                <View key={row[0].url} style={styles.alignCenter}>
-                    <View key={row[0].url} style={[styles.expandedView, { borderRadius: this.props.borderRadius }]}>
-                        <TouchableOpacity onPress={() => { this.photoPopupToggle(row[0].url) }}>
-                            <Image source={{ uri: row[0].url }} style={[styles.ImageStyle, styles.expandedImage, { borderRadius: this.props.borderRadius }]} />
-                            {children && children(row[0])}
-                        </TouchableOpacity>
-                    </View>
+                <View key={index} style={styles.alignCenter}>
+                    {this.renderItem(row[0], index, true)}
                 </View>
             )
         }
         else if (row.length == 2) {
             return (
-                <View key={row[0].url} style={styles.alignCenter}>
-                    <View key={row[0].url} style={[styles.expandedView, { borderRadius: this.props.borderRadius }]}>
-                        <TouchableOpacity onPress={() => { this.photoPopupToggle(row[0].url) }}>
-                            <Image source={{ uri: row[0].url }} style={[styles.ImageStyle, styles.expandedImage, { borderRadius: this.props.borderRadius }]} />
-                            {children && children(row[0])}
-                        </TouchableOpacity>
-                    </View>
-                    <View key={row[1].url} style={styles.flexCol}>
-                        <View style={[styles.photoView, { borderRadius: this.props.borderRadius }]}>
-                            <TouchableOpacity onPress={() => { this.photoPopupToggle(row[1].url) }}>
-                                <Image source={{ uri: row[1].url }} style={[styles.ImageStyle, { borderRadius: this.props.borderRadius }]} />
-                                {children && children(row[1])}
-                            </TouchableOpacity>
-                        </View>
+                <View key={index} style={styles.alignCenter}>
+                    {this.renderItem(row[0], index, true)}
+                    <View key={index + 1} style={styles.flexCol}>
+                        {this.renderItem(row[1], index + 1, false)}
                     </View>
                 </View>
             )
@@ -117,26 +105,11 @@ class PhotoGrid extends Component {
         }
         else if (row.length == 3) {
             return (
-                <View key={row[0].url} style={styles.alignCenter}>
-                    <View key={row[0].url} style={[styles.expandedView, { borderRadius: this.props.borderRadius }]}>
-                        <TouchableOpacity onPress={() => { this.photoPopupToggle(row[0].url) }}>
-                            <Image source={{ uri: row[0].url }} style={[styles.ImageStyle, styles.expandedImage, { borderRadius: this.props.borderRadius }]} />
-                            {children && children(row[0])}
-                        </TouchableOpacity>
-                    </View>
-                    <View key={row[1].url} style={styles.flexCol}>
-                        <View style={[styles.photoView, { borderRadius: this.props.borderRadius }]}>
-                            <TouchableOpacity onPress={() => { this.photoPopupToggle(row[1].url) }}>
-                                <Image source={{ uri: row[1].url }} style={[styles.ImageStyle, { borderRadius: this.props.borderRadius }]} />
-                                {children && children(row[1])}
-                            </TouchableOpacity>
-                        </View>
-                        <View style={[styles.photoView, { borderRadius: this.props.borderRadius }]}>
-                            <TouchableOpacity onPress={() => { this.photoPopupToggle(row[2].url) }}>
-                                <Image source={{ uri: row[2].url }} style={[styles.ImageStyle, { borderRadius: this.props.borderRadius }]} />
-                                {children && children(row[2])}
-                            </TouchableOpacity>
-                        </View>
+                <View key={index} style={styles.alignCenter}>
+                    {this.renderItem(row[0], index, true)}
+                    <View key={index + 1} style={styles.flexCol}>
+                        {this.renderItem(row[1], index + 1, false)}
+                        {this.renderItem(row[2], index + 2, false)}
                     </View>
                 </View>
             )
@@ -144,39 +117,22 @@ class PhotoGrid extends Component {
         }
 
     }
-    renderPhotoRow3(row) {
-        const { children } = this.props;
+    renderPhotoRow3(row, index) {
         if (row.length == 1) {
             return (
-                <View key={row[0].url} style={styles.alignCenter}>
-                    <View key={row[0].url} style={styles.flexCol}>
-                        <View style={[styles.photoView, { borderRadius: this.props.borderRadius }]}>
-                            <TouchableOpacity onPress={() => { this.photoPopupToggle(row[0].url) }}>
-                                <Image source={{ uri: row[0].url }} style={[styles.ImageStyle, { borderRadius: this.props.borderRadius }]} />
-                                {children && children(row[0])}
-                            </TouchableOpacity>
-                        </View>
-
+                <View key={index} style={styles.alignCenter}>
+                    <View key={index} style={styles.flexCol}>
+                        {this.renderItem(row[0], index, false)}
                     </View>
                 </View>
             )
         }
         else if (row.length == 2) {
             return (
-                <View key={row[0].url} style={styles.alignCenter}>
-                    <View key={row[0].url} style={styles.flexCol}>
-                        <View style={[styles.photoView, { borderRadius: this.props.borderRadius }]}>
-                            <TouchableOpacity onPress={() => { this.photoPopupToggle(row[0].url) }}>
-                                <Image source={{ uri: row[0].url }} style={[styles.ImageStyle, { borderRadius: this.props.borderRadius }]} />
-                                {children && children(row[0])}
-                            </TouchableOpacity>
-                        </View>
-                        <View key={row[1].url} style={[styles.photoView, { borderRadius: this.props.borderRadius }]}>
-                            <TouchableOpacity onPress={() => { this.photoPopupToggle(row[1].url) }}>
-                                <Image source={{ uri: row[1].url }} style={[styles.ImageStyle, { borderRadius: this.props.borderRadius }]} />
-                                {children && children(row[1])}
-                            </TouchableOpacity>
-                        </View>
+                <View key={index} style={styles.alignCenter}>
+                    <View key={index} style={styles.flexCol}>
+                        {this.renderItem(row[0], index, false)}
+                        {this.renderItem(row[1], index + 1, false)}
                     </View>
                 </View>
             )
@@ -184,28 +140,13 @@ class PhotoGrid extends Component {
         }
         else if (row.length == 3) {
             return (
-                <View key={row[0].url} style={styles.alignCenter}>
+                <View key={index} style={styles.alignCenter}>
 
                     <View style={styles.flexCol}>
-                        <View style={[styles.photoView, { borderRadius: this.props.borderRadius }]}>
-                            <TouchableOpacity onPress={() => { this.photoPopupToggle(row[0].url) }}>
-                                <Image source={{ uri: row[0].url }} style={[styles.ImageStyle, { borderRadius: this.props.borderRadius }]} />
-                                {children && children(row[0])}
-                            </TouchableOpacity>
-                        </View>
-                        <View style={[styles.photoView, { borderRadius: this.props.borderRadius }]}>
-                            <TouchableOpacity onPress={() => { this.photoPopupToggle(row[1].url) }}>
-                                <Image source={{ uri: row[1].url }} style={[styles.ImageStyle, { borderRadius: this.props.borderRadius }]} />
-                                {children && children(row[1])}
-                            </TouchableOpacity>
-                        </View>
+                        {this.renderItem(row[0], index, false)}
+                        {this.renderItem(row[1], index + 1, false)}
                     </View>
-                    <View style={[styles.expandedView, { borderRadius: this.props.borderRadius }]}>
-                        <TouchableOpacity onPress={() => { this.photoPopupToggle(row[2].url) }}>
-                            <Image source={{ uri: row[2].url }} style={[styles.ImageStyle, styles.expandedImage, { borderRadius: this.props.borderRadius }]} />
-                            {children && children(row[2])}
-                        </TouchableOpacity>
-                    </View>
+                    {this.renderItem(row[2], index + 2, true)}
                 </View>
             )
 

--- a/PhotoGrid.js
+++ b/PhotoGrid.js
@@ -53,6 +53,7 @@ class PhotoGrid extends Component {
 
     }
     renderPhotoRow1(row) {
+        const { children } = this.props;
         console.log('row', row);
         return (
             <View key={1} style={styles.alignCenter}>
@@ -63,6 +64,7 @@ class PhotoGrid extends Component {
                                 <View key={index} style={[styles.photoView, { borderRadius: this.props.borderRadius }]}>
                                     <TouchableOpacity onPress={() => { this.photoPopupToggle(item.url) }}>
                                         <Image source={{ uri: item.url }} style={[styles.ImageStyle, { borderRadius: this.props.borderRadius }]} />
+                                        {children && children(item)}
                                     </TouchableOpacity>
                                 </View>
                             )
@@ -75,13 +77,14 @@ class PhotoGrid extends Component {
         )
     }
     renderPhotoRow2(row) {
-
+        const { children } = this.props;
         if (row.length == 1) {
             return (
                 <View key={row[0].url} style={styles.alignCenter}>
                     <View key={row[0].url} style={[styles.expandedView, { borderRadius: this.props.borderRadius }]}>
                         <TouchableOpacity onPress={() => { this.photoPopupToggle(row[0].url) }}>
                             <Image source={{ uri: row[0].url }} style={[styles.ImageStyle, styles.expandedImage, { borderRadius: this.props.borderRadius }]} />
+                            {children && children(row[0])}
                         </TouchableOpacity>
                     </View>
                 </View>
@@ -93,12 +96,14 @@ class PhotoGrid extends Component {
                     <View key={row[0].url} style={[styles.expandedView, { borderRadius: this.props.borderRadius }]}>
                         <TouchableOpacity onPress={() => { this.photoPopupToggle(row[0].url) }}>
                             <Image source={{ uri: row[0].url }} style={[styles.ImageStyle, styles.expandedImage, { borderRadius: this.props.borderRadius }]} />
+                            {children && children(row[0])}
                         </TouchableOpacity>
                     </View>
                     <View key={row[1].url} style={styles.flexCol}>
                         <View style={[styles.photoView, { borderRadius: this.props.borderRadius }]}>
                             <TouchableOpacity onPress={() => { this.photoPopupToggle(row[1].url) }}>
                                 <Image source={{ uri: row[1].url }} style={[styles.ImageStyle, { borderRadius: this.props.borderRadius }]} />
+                                {children && children(row[1])}
                             </TouchableOpacity>
                         </View>
                     </View>
@@ -112,17 +117,20 @@ class PhotoGrid extends Component {
                     <View key={row[0].url} style={[styles.expandedView, { borderRadius: this.props.borderRadius }]}>
                         <TouchableOpacity onPress={() => { this.photoPopupToggle(row[0].url) }}>
                             <Image source={{ uri: row[0].url }} style={[styles.ImageStyle, styles.expandedImage, { borderRadius: this.props.borderRadius }]} />
+                            {children && children(row[0])}
                         </TouchableOpacity>
                     </View>
                     <View key={row[1].url} style={styles.flexCol}>
                         <View style={[styles.photoView, { borderRadius: this.props.borderRadius }]}>
                             <TouchableOpacity onPress={() => { this.photoPopupToggle(row[1].url) }}>
                                 <Image source={{ uri: row[1].url }} style={[styles.ImageStyle, { borderRadius: this.props.borderRadius }]} />
+                                {children && children(row[1])}
                             </TouchableOpacity>
                         </View>
                         <View style={[styles.photoView, { borderRadius: this.props.borderRadius }]}>
                             <TouchableOpacity onPress={() => { this.photoPopupToggle(row[2].url) }}>
                                 <Image source={{ uri: row[2].url }} style={[styles.ImageStyle, { borderRadius: this.props.borderRadius }]} />
+                                {children && children(row[2])}
                             </TouchableOpacity>
                         </View>
                     </View>
@@ -133,7 +141,7 @@ class PhotoGrid extends Component {
 
     }
     renderPhotoRow3(row) {
-
+        const { children } = this.props;
         if (row.length == 1) {
             return (
                 <View key={row[0].url} style={styles.alignCenter}>
@@ -141,6 +149,7 @@ class PhotoGrid extends Component {
                         <View style={[styles.photoView, { borderRadius: this.props.borderRadius }]}>
                             <TouchableOpacity onPress={() => { this.photoPopupToggle(row[0].url) }}>
                                 <Image source={{ uri: row[0].url }} style={[styles.ImageStyle, { borderRadius: this.props.borderRadius }]} />
+                                {children && children(row[0])}
                             </TouchableOpacity>
                         </View>
 
@@ -155,11 +164,13 @@ class PhotoGrid extends Component {
                         <View style={[styles.photoView, { borderRadius: this.props.borderRadius }]}>
                             <TouchableOpacity onPress={() => { this.photoPopupToggle(row[0].url) }}>
                                 <Image source={{ uri: row[0].url }} style={[styles.ImageStyle, { borderRadius: this.props.borderRadius }]} />
+                                {children && children(row[0])}
                             </TouchableOpacity>
                         </View>
                         <View key={row[1].url} style={[styles.photoView, { borderRadius: this.props.borderRadius }]}>
                             <TouchableOpacity onPress={() => { this.photoPopupToggle(row[1].url) }}>
                                 <Image source={{ uri: row[1].url }} style={[styles.ImageStyle, { borderRadius: this.props.borderRadius }]} />
+                                {children && children(row[1])}
                             </TouchableOpacity>
                         </View>
                     </View>
@@ -175,17 +186,20 @@ class PhotoGrid extends Component {
                         <View style={[styles.photoView, { borderRadius: this.props.borderRadius }]}>
                             <TouchableOpacity onPress={() => { this.photoPopupToggle(row[0].url) }}>
                                 <Image source={{ uri: row[0].url }} style={[styles.ImageStyle, { borderRadius: this.props.borderRadius }]} />
+                                {children && children(row[0])}
                             </TouchableOpacity>
                         </View>
                         <View style={[styles.photoView, { borderRadius: this.props.borderRadius }]}>
                             <TouchableOpacity onPress={() => { this.photoPopupToggle(row[1].url) }}>
                                 <Image source={{ uri: row[1].url }} style={[styles.ImageStyle, { borderRadius: this.props.borderRadius }]} />
+                                {children && children(row[1])}
                             </TouchableOpacity>
                         </View>
                     </View>
                     <View style={[styles.expandedView, { borderRadius: this.props.borderRadius }]}>
                         <TouchableOpacity onPress={() => { this.photoPopupToggle(row[2].url) }}>
                             <Image source={{ uri: row[2].url }} style={[styles.ImageStyle, styles.expandedImage, { borderRadius: this.props.borderRadius }]} />
+                            {children && children(row[2])}
                         </TouchableOpacity>
                     </View>
                 </View>


### PR DESCRIPTION
Allows overlaying the image with a child component and lets you override `photoPopupToggle` with a custom action when an item is pressed.
This also allows the use of a custom Image component (like FastImage) with an option to passthrough props.
![IMG_2842](https://user-images.githubusercontent.com/5898658/75746070-69b40000-5d5c-11ea-8ac8-6dedb002cade.jpeg)
